### PR TITLE
Add helper script to optionally run kubectl/helm/helmfile from Docker

### DIFF
--- a/run-with-docker.sh
+++ b/run-with-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# A helper script to start a Docker environment with kubectl helm helmfile
+# preinstalled
+
+if [ "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" != "$PWD" ]; then
+    echo Must be run from script parent directory
+    exit 2
+fi
+
+if [ $# -ne 1 ]; then
+    echo USAGE $(basename $0) path/to/kube-config
+    exit 1
+fi
+
+KUBECONFIG=$(realpath $1)
+shift
+
+exec docker run -it --rm \
+    -v "$KUBECONFIG:/home/kube/.kube/config" \
+    -v "$PWD/..:/k8s:ro" -w /k8s/apps \
+    kube-helm-docker "$@"

--- a/run-with-docker.sh
+++ b/run-with-docker.sh
@@ -19,4 +19,4 @@ shift
 exec docker run -it --rm \
     -v "$KUBECONFIG:/home/kube/.kube/config" \
     -v "$PWD/..:/k8s:ro" -w /k8s/apps \
-    kube-helm-docker "$@"
+    imagedata/kube-helm-docker "$@"


### PR DESCRIPTION
These can all be run natively. This script provides an optional preconfigured environment for anyone who doesn't want to install kubectl helm helmfile.

Takes advantage of https://github.com/IDR/kube-helm-docker/pull/1