### PR TITLE
kube-system/star-openmicroscopy-org-20190911

### DIFF
--- a/nginx-ingress/nginx-ingress.yml
+++ b/nginx-ingress/nginx-ingress.yml
@@ -14,4 +14,4 @@ controller:
 # Optionally specify SSL certificate
 # https://github.com/kubernetes/charts/issues/1495#issuecomment-342275665
   extraArgs:
-    default-ssl-certificate: kube-system/star-openmicroscopy-org-20181009
+    default-ssl-certificate: kube-system/star-openmicroscopy-org-20190911


### PR DESCRIPTION
Update k8s Nginx certificate

Deployed following instructions in https://github.com/ome/kubernetes-apps/tree/544953c7b40a71df8f9c9e60c4f1f3bedd82a412/nginx-ingress with https://github.com/ome/kubernetes-apps/pull/11
```
kubectl create --namespace=kube-system secret tls star-openmicroscopy-org-20190911 --key star_openmicroscopy_org.key --cert star_openmicroscopy_org.crt+bundle

./run-with-docker.sh ome-lochy.kubeconfig

helmfile -l name=nginx-ingress diff
helmfile -l name=nginx-ingress sync

kubectl -n nginx-ingress delete pods -l app=nginx-ingress,component=controller
```