### PR TITLE
K8s resource names must be DNS safe

### DIFF
--- a/nginx-ingress/nginx-ingress.yml
+++ b/nginx-ingress/nginx-ingress.yml
@@ -14,4 +14,4 @@ controller:
 # Optionally specify SSL certificate
 # https://github.com/kubernetes/charts/issues/1495#issuecomment-342275665
   extraArgs:
-    default-ssl-certificate: kube-system/star_openmicroscopy_org-20200824
+    default-ssl-certificate: kube-system/star-openmicroscopy-org-20200824


### PR DESCRIPTION
$ kubectl create --namespace=kube-system secret tls star_openmicroscopy_org-20200824 --key key --cert crt+bundle
The Secret "star_openmicroscopy_org-20200824" is invalid: metadata.name: Invalid value: "star_openmicroscopy_org-20200824": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')